### PR TITLE
chore: Update repository URLs and add semantic-release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,14 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/naaiyy/Easylink.git"
+    "url": "git+https://github.com/naaiyy/Easylink-2.git"
   },
   "bugs": {
-    "url": "https://github.com/naaiyy/Easylink/issues"
+    "url": "https://github.com/naaiyy/Easylink-2/issues"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",


### PR DESCRIPTION
This PR updates the repository configuration to enable semantic-release:

- Added `.releaserc` with proper semantic-release configuration
- Updated repository URLs in `package.json` to point to the new repository

After merging this PR, semantic-release should create the first release.