### PR TITLE
chore(root): Configure semantic-release for pre-1.0 development

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,8 +11,7 @@
         {"type": "refactor", "release": "patch"},
         {"type": "perf", "release": "patch"},
         {"type": "test", "release": "patch"}
-      ],
-      "firstRelease": "0.0.1"
+      ]
     }],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
@@ -22,5 +21,7 @@
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     "@semantic-release/github"
-  ]
+  ],
+  "prerelease": true,
+  "firstRelease": "0.0.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# 1.0.0 (2025-01-10)
-
-### Features
-
-- **shared:** Add initial configuration functionality ([e015d2d](https://github.com/naaiyy/Easylink-2/commit/e015d2d3fd20c87dde73a3b0aaf374b676062c7c))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easylink",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "",
   "type": "module",
   "private": true,


### PR DESCRIPTION
This PR:

- Configures semantic-release for pre-1.0 development
- Resets version to 0.0.0
- Removes CHANGELOG.md for fresh start
- Adds prerelease configuration to ensure versions stay in 0.x.x range